### PR TITLE
Use Collections.shuffle to shuffle combinations.

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/ScriptRunner.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/ScriptRunner.groovy
@@ -26,7 +26,7 @@ class ScriptRunner {
     @SuppressWarnings('InsecureRandom')
     Map run( List<Combination> c) {
 
-        c.sort { Math.random() }
+        java.util.Collections.shuffle(c)
 
         Binding binding = new Binding()
         binding.setVariable('jenkins', Jenkins.instance)


### PR DESCRIPTION
`c.sort { Math.random() }` is a very broken way how to shuffle a list:

-- Math.random returns double from [0,1) interval,  but comparator need to return values -1, 0, 1, which breaks the purpose of randomization (all elements will treated as "greater" than other elements).
-- The comparator function is not stable, so if two elements are compared twice, this can result in "java.lang.IllegalArgumentException: Comparison method violates its general contract" exception. 

See https://github.com/grpc/grpc/issues/3736 caused by this.
