### PR TITLE
Read script from slave node instead of master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 }
 
 group = 'org.jenkins-ci.plugins'
-version = '1.0.7'
+version = '1.0.8'
 description = 'Matrix Groovy Execution Strategy Plugin'
 
 task wrapper(type: Wrapper) {

--- a/src/main/groovy/org/jenkinsci/plugins/GroovyScriptMES.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/GroovyScriptMES.groovy
@@ -51,7 +51,7 @@ class GroovyScriptMES extends BaseMES {
         } else if (! Jenkins.instance.getDescriptor(this.class).secureOnly) {
             List<ClasspathEntry> cp = []
 
-            def scriptInFile = new WorkspaceFileReader(scriptFile).scriptFile.text
+            def scriptInFile = new WorkspaceFileReader(scriptFile).scriptContent
             myScript = new SecureGroovyScript(scriptInFile, false, cp).configuring(ApprovalContext.create())
             myScript.configuringWithKeyItem()
         } else {

--- a/src/main/groovy/org/jenkinsci/plugins/WorkspaceFileReader.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/WorkspaceFileReader.groovy
@@ -1,28 +1,33 @@
 package org.jenkinsci.plugins
 
 import hudson.model.OneOffExecutor
+import hudson.FilePath;
 
 /**
  * Created by jeremymarshall on 22/10/14.
  */
 class WorkspaceFileReader {
 
-    @Delegate Reader scriptFile
+    String scriptContent
     String workspace
+    hudson.remoting.VirtualChannel channel
 
     WorkspaceFileReader() {
         OneOffExecutor thr = Thread.currentThread()
         this.workspace = thr.currentWorkspace
+        this.channel = thr.getOwner().getChannel()
     }
 
     WorkspaceFileReader(String file) {
         this()
         File f = new File(file)
 
+        String path
         if (f.isAbsolute()) {
-            scriptFile = new FileReader(file)
+            path = file
         } else {
-            scriptFile = new FileReader(workspace + File.separator + file)
+            path = workspace + File.separator + file
         }
+        this.scriptContent = new FilePath(this.channel, path).readToString()
     }
 }


### PR DESCRIPTION
Fixes #19 
I am not familiar with Jenkins plugin development, but from what I have read in the documentation we cannot use `File` to read a file that is potentially on a node different from master/built-in, where the plugin is running. The proper way is to use `FilePath`. I tried to simply read the text from the remote file and pass it around, to keep the rest of the plugin as simple as possible.
I did not have a chance to test it because I don't have anything setup to do so, I would kindly ask anybody with more experience to look at the very simple changes I made and give them a try if they make sense.
