### PR TITLE
Add "Use Groovy Sandbox" checkbox for script from filesystem

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/GroovyScriptMES.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/GroovyScriptMES.groovy
@@ -25,12 +25,14 @@ class GroovyScriptMES extends BaseMES {
     transient String script
     String scriptFile
     String scriptType = 'script'
+    boolean sandbox = false
 
     @DataBoundConstructor
-    GroovyScriptMES( SecureGroovyScript secureScript, String scriptFile, String scriptType) {
+    GroovyScriptMES( SecureGroovyScript secureScript, String scriptFile, String scriptType, boolean sandbox) {
         this.secureScript = secureScript
         this.scriptFile = scriptFile
         this.scriptType = scriptType
+        this.sandbox = sandbox
 
         this.secureScript.configuringWithKeyItem()
     }
@@ -52,7 +54,7 @@ class GroovyScriptMES extends BaseMES {
             List<ClasspathEntry> cp = []
 
             def scriptInFile = new WorkspaceFileReader(scriptFile).scriptContent
-            myScript = new SecureGroovyScript(scriptInFile, false, cp).configuring(ApprovalContext.create())
+            myScript = new SecureGroovyScript(scriptInFile, this.sandbox, cp).configuring(ApprovalContext.create())
             myScript.configuringWithKeyItem()
         } else {
             throw new GroovyScriptInFileException('')
@@ -69,7 +71,7 @@ class GroovyScriptMES extends BaseMES {
         if (script != null) {
             List<ClasspathEntry> cp = []
 
-            secureScript = new SecureGroovyScript(script, false, cp).configuring(ApprovalContext.create())
+            secureScript = new SecureGroovyScript(script, this.sandbox, cp).configuring(ApprovalContext.create())
             script = null
         }
         this

--- a/src/main/resources/org/jenkinsci/plugins/GroovyScriptMES/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/GroovyScriptMES/config.groovy
@@ -18,6 +18,7 @@ namespace(lib.FormTagLib).with {
         invisibleEntry {
             input( name: "scriptFile", value: "", type: "hidden")
             input( name: "scriptType", value: "script", type: "hidden")
+            input( name: "sandbox", value: false, type: "hidden")
         }
     } else {
         radioBlock(name: 'scriptType', title: 'Groovy Script', value: 'script', checked = instance ? instance.scriptType.equals('script') : true, inline: true) {
@@ -26,6 +27,9 @@ namespace(lib.FormTagLib).with {
         radioBlock(name: 'scriptType', title: 'Groovy File', value: 'file', checked = instance?.scriptType.equals('file'), inline: true) {
             entry(title: _("Groovy File"), field: "scriptFile") {
                 textbox()
+            }
+            entry(title: _("Use Groovy Sandbox"), field: "sandbox") {
+                checkbox()
             }
         }
     }

--- a/src/test/groovy/org/jenkinsci/plugins/GroovyScriptMESSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/GroovyScriptMESSpec.groovy
@@ -82,7 +82,7 @@ class GroovyScriptMESSpec extends Specification {
         given:
 
         def matrixProject = configure()
-        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(script, false), '', 'script')
+        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(script, false), '', 'script', false)
 
         when:
         def build = matrixProject.scheduleBuild2(0).get()
@@ -99,7 +99,7 @@ class GroovyScriptMESSpec extends Specification {
         given:
 
         def matrixProject = configure()
-        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript('', false), '', 'script')
+        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript('', false), '', 'script', false)
 
         when:
         def build = matrixProject.scheduleBuild2(0).get()
@@ -116,7 +116,7 @@ class GroovyScriptMESSpec extends Specification {
         given:
 
         def matrixProject = configure(true)
-        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(script, false), '', 'script')
+        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(script, false), '', 'script', false)
 
         when:
         def build = matrixProject.scheduleBuild2(0).get()
@@ -134,7 +134,7 @@ class GroovyScriptMESSpec extends Specification {
         given:
 
         def matrixProject = configure(true)
-        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(scriptCont, false), '', 'script')
+        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript(scriptCont, false), '', 'script', false)
 
         when:
         def build = matrixProject.scheduleBuild2(0).get()
@@ -152,7 +152,7 @@ class GroovyScriptMESSpec extends Specification {
         given:
 
         def matrixProject = configure(true)
-        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript('', false), '', 'script')
+        matrixProject.executionStrategy = new GroovyScriptMES(new SecureGroovyScript('', false), '', 'script', false)
 
         when:
         def build = matrixProject.scheduleBuild2(0).get()


### PR DESCRIPTION
This allows the script to run in an environment where we don't have access to all the Jenkins internal classes, but does not require manual approval of every new version of the script (in case it is read from SCM)

This was tested in our local jenkins: the plugin correctly reads the checkbox as expected and runs the script in the sandbox whenever the checkbox is selected

Fixes #9 